### PR TITLE
Add missed class for accordion

### DIFF
--- a/addon/components/f-accordion-panel.js
+++ b/addon/components/f-accordion-panel.js
@@ -9,5 +9,7 @@ export default FComponent.extend({
     return this.get('elementId') + '-panel';
   }.property('elementId'),
 
+  classNames: ['accordion-navigation'],
+
   tagName: 'dd'
 });


### PR DESCRIPTION
Hi!

Here is small fix for none-working accordions.

According to the [Foundation Docs](http://foundation.zurb.com/docs/components/accordion.html)
`<dd>` elements should have class `accordion-navigation` and without it I have no success to make accordions work after fetching the latest code from your repository (it just changes the location but panels stays closed).

Thanks!