### PR TITLE
Remove deprecation warnings for Ember 2.2.0

### DIFF
--- a/app/initializers/ember-foundation.js
+++ b/app/initializers/ember-foundation.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default {
   name: 'ember-foundation',
 
-  initialize(container, app) {
+  initialize(app) {
     app.inject('component:f-breadcrumbs', 'router', 'router:main');
   }
 };


### PR DESCRIPTION
DEPRECATION: The `initialize` method for Application initializer 'ember-foundation' should take only one argument - `App`, an instance of an `Application`. [deprecation id: ember-application.app-initializer-initialize-arguments] See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity for more details.